### PR TITLE
Fix git clone argument.

### DIFF
--- a/primitiv-sys/build.rs
+++ b/primitiv-sys/build.rs
@@ -82,9 +82,7 @@ fn build_from_src() -> Result<(), Box<Error>> {
         log_var!(source);
         if !source.exists() {
             run("git", |command| {
-                command.arg("clone").arg("--depth=1").arg(REPOSITORY).arg(
-                    &source,
-                )
+                command.arg("clone").arg(REPOSITORY).arg(&source)
             });
             run("git", |command| {
                 command


### PR DESCRIPTION
Related to #6 
This PR fixes wrong git clone option `--depth=1`.
With `--depth` option, a repository is cloned with a history truncated to the specified number of revisions.
Then `git checkout` command with an older revision number fails because the shallow repository does not include it.
This PR removes `--depth` option to clone a repository without truncating a history. 